### PR TITLE
Publish DocumentDB CoonectionString in Status fields

### DIFF
--- a/api/preview/documentdb_types.go
+++ b/api/preview/documentdb_types.go
@@ -63,7 +63,8 @@ type Timeouts struct {
 // DocumentDBStatus defines the observed state of DocumentDB.
 type DocumentDBStatus struct {
 	// Status reflects the status field from the underlying CNPG Cluster.
-	Status string `json:"status,omitempty"`
+	Status           string `json:"status,omitempty"`
+	ConnectionString string `json:"connectionString,omitempty"`
 }
 
 // +kubebuilder:printcolumn:name="Status",type=string,JSONPath=".status.status",description="CNPG Cluster Status"

--- a/config/crd/bases/db.microsoft.com_documentdbs.yaml
+++ b/config/crd/bases/db.microsoft.com_documentdbs.yaml
@@ -118,6 +118,8 @@ spec:
           status:
             description: DocumentDBStatus defines the observed state of DocumentDB.
             properties:
+              connectionString:
+                type: string
               status:
                 description: Status reflects the status field from the underlying
                   CNPG Cluster.

--- a/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
+++ b/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
@@ -118,6 +118,8 @@ spec:
           status:
             description: DocumentDBStatus defines the observed state of DocumentDB.
             properties:
+              connectionString:
+                type: string
               status:
                 description: Status reflects the status field from the underlying
                   CNPG Cluster.

--- a/scripts/deployment-examples/single-node-documentdb.yaml
+++ b/scripts/deployment-examples/single-node-documentdb.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   nodeCount: 1
   instancesPerNode: 1
-  documentDBImage: ghcr.io/microsoft/documentdb-kubernetes-operator/documentdb-local:16
+  documentDBImage: ghcr.io/microsoft/documentdb/documentdb-local:16
   resource:
     pvcSize: 10Gi
   publicLoadBalancer:


### PR DESCRIPTION
If public load balancer is enabled, use the load balancer ip to generate the DocumentDB connection string and publish it in the status fields.

This is the start to make things easier when load balancer is enabled. For without loadbalancer, we need extra thinking which will come in separate PRs.

**Test:**
- Verified by deploying in AKS cluster with Azure public load balancer.