### PR TITLE
Make Gateway sidecar image configurable through sidecar-injector

### DIFF
--- a/api/preview/documentdb_types.go
+++ b/api/preview/documentdb_types.go
@@ -25,6 +25,10 @@ type DocumentDBSpec struct {
 	// DocumentDBImage is the container image to use for DocumentDB.
 	DocumentDBImage string `json:"documentDBImage"`
 
+	// GatewayImage is the container image to use for the DocumentDB Gateway sidecar.
+	// If not specified, defaults to a version that matches the DocumentDB operator version.
+	GatewayImage string `json:"gatewayImage,omitempty"`
+
 	// ClusterReplication configures cross-cluster replication for DocumentDB.
 	ClusterReplication *ClusterReplication `json:"clusterReplication,omitempty"`
 

--- a/config/crd/bases/db.microsoft.com_documentdbs.yaml
+++ b/config/crd/bases/db.microsoft.com_documentdbs.yaml
@@ -87,6 +87,11 @@ spec:
                 required:
                 - serviceType
                 type: object
+              gatewayImage:
+                description: |-
+                  GatewayImage is the container image to use for the DocumentDB Gateway sidecar.
+                  If not specified, defaults to a version that matches the DocumentDB operator version.
+                type: string
               instancesPerNode:
                 description: InstancesPerNode is the number of DocumentDB instances
                   per node. Must be 1.

--- a/docs/sidecar-injector-plugin-configuration.md
+++ b/docs/sidecar-injector-plugin-configuration.md
@@ -1,0 +1,160 @@
+# Sidecar Injector Plugin Configuration
+
+## Overview
+
+The DocumentDB Sidecar Injector is a CNPG plugin that automatically injects the DocumentDB Gateway container into PostgreSQL pods. The plugin supports multiple configuration parameters that can be customized through the DocumentDB custom resource specification. This follows CNPG's plugin parameter pattern where configuration is passed from the operator to the sidecar injector plugin.
+
+## Configuration Flow
+
+```
+DocumentDB CR Spec
+    ↓
+DocumentDB Controller 
+    ↓ 
+CNPG Cluster with Plugin Parameters
+    ↓
+Sidecar Injector Plugin
+    ↓
+Pod with Configured Sidecar Containers and Metadata
+```
+
+## Configuration Parameters
+
+The sidecar injector plugin supports the following configuration parameters:
+
+### 1. Gateway Image Configuration
+
+Controls which DocumentDB Gateway container image is injected into PostgreSQL pods.
+
+#### Configuration Options
+
+**Per DocumentDB Instance (Explicit):**
+```yaml
+apiVersion: db.microsoft.com/v1
+kind: DocumentDB
+metadata:
+  name: my-documentdb
+  namespace: default
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  resource:
+    pvcSize: "10Gi"
+  documentDBImage: "mcr.microsoft.com/documentdb/documentdb:16-v1.3.0"
+  # Explicitly specify gateway image
+  gatewayImage: "ghcr.io/microsoft/documentdb/documentdb-local:17"
+  exposeViaService:
+    serviceType: "ClusterIP"
+```
+
+**Global Default (Environment Variable):**
+```bash
+# Set globally for the operator deployment (unified versioning)
+export DOCUMENTDB_GATEWAY_IMAGE="ghcr.io/microsoft/documentdb/documentdb-local:17"
+```
+
+**Built-in Fallback:**
+If neither explicit spec nor environment variable is set, the system falls back to:
+```
+ghcr.io/microsoft/documentdb/documentdb-local:16
+```
+
+### 2. Pod Labels Configuration
+
+Controls additional labels that are applied to injected pods.
+
+```yaml
+# Example: Custom labels via plugin parameters
+plugins:
+  - name: cnpg-i-sidecar-injector.documentdb.io
+    parameters:
+      labels: '{"environment":"production","team":"data"}'
+```
+
+### 3. Pod Annotations Configuration
+
+Controls additional annotations that are applied to injected pods.
+
+```yaml
+# Example: Custom annotations via plugin parameters
+plugins:
+  - name: cnpg-i-sidecar-injector.documentdb.io
+    parameters:
+      annotations: '{"prometheus.io/scrape":"true","prometheus.io/port":"8080"}'
+```
+
+## CNPG Plugin Parameters
+
+The DocumentDB controller automatically passes all configuration parameters to the sidecar injector plugin via CNPG's plugin parameter mechanism:
+
+```yaml
+# Generated CNPG Cluster with all plugin parameters
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: my-documentdb
+spec:
+  plugins:
+    - name: cnpg-i-sidecar-injector.documentdb.io
+      parameters:
+        gatewayImage: "ghcr.io/microsoft/documentdb/documentdb-local:17"
+        labels: '{"environment":"production","team":"data"}'
+        annotations: '{"prometheus.io/scrape":"true"}'
+```
+
+## Configuration Examples
+
+### Basic Configuration (Gateway Image Only)
+
+```yaml
+apiVersion: db.microsoft.com/v1
+kind: DocumentDB
+metadata:
+  name: basic-documentdb
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  resource:
+    pvcSize: "10Gi"
+  gatewayImage: "ghcr.io/microsoft/documentdb/documentdb-local:17"
+```
+
+### Advanced Configuration (All Parameters)
+
+```yaml
+apiVersion: db.microsoft.com/v1
+kind: DocumentDB
+metadata:
+  name: advanced-documentdb
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  resource:
+    pvcSize: "20Gi"
+  documentDBImage: "mcr.microsoft.com/documentdb/documentdb:16-v1.3.0"
+  gatewayImage: "ghcr.io/microsoft/documentdb/documentdb-local:17"
+  sidecarInjectorPluginName: "cnpg-i-sidecar-injector.documentdb.io"
+  exposeViaService:
+    serviceType: "LoadBalancer"
+```
+
+### Environment-Based Configuration (Unified Versioning)
+
+```bash
+# Set globally for unified versioning
+export DOCUMENTDB_GATEWAY_IMAGE="ghcr.io/microsoft/documentdb/documentdb-local:17"
+
+# Deploy without explicit gateway image - uses environment default
+kubectl apply -f - <<EOF
+apiVersion: db.microsoft.com/v1
+kind: DocumentDB
+metadata:
+  name: env-configured-documentdb
+spec:
+  nodeCount: 1
+  instancesPerNode: 1
+  resource:
+    pvcSize: "15Gi"
+EOF
+```
+

--- a/docs/v1/index.md
+++ b/docs/v1/index.md
@@ -347,6 +347,24 @@ documentdb-service-documentdb-preview   LoadBalancer   10.0.228.243   52.149.56.
 
 > If you are using the Python program to connect to DocumentDB, make sure to update the script's `host` variable with the external IP of your `documentdb-service-documentdb-preview` LoadBalancer service. Additionally, ensure that you update the default `password` in the script or, preferably, use environment variables to securely manage sensitive information like passwords.
 
+## Configuration and Advanced Topics
+
+Now that you have a basic DocumentDB cluster running, you may want to explore advanced configuration options and operational guides:
+
+### Sidecar Injector Plugin Configuration
+
+The DocumentDB operator uses a sidecar injector plugin to automatically inject the DocumentDB Gateway container into PostgreSQL pods. This plugin supports multiple configuration parameters including:
+
+- **Gateway Image Configuration**: Customize which DocumentDB Gateway container image is used
+- **Pod Labels and Annotations**: Add custom metadata to injected pods
+
+For detailed information on configuring the sidecar injector plugin, see: [Sidecar Injector Plugin Configuration](../sidecar-injector-plugin-configuration.md)
+
+
+### Multi-Cloud Deployment
+
+The DocumentDB operator supports deployment across multiple cloud environments and Kubernetes distributions. For guidance on multi-cloud deployments, see: [Multi-Cloud Deployment Guide](../multi-cloud-deployment-guide.md)
+
 ### Delete the DocumentDB cluster and other resources
 
 ```sh

--- a/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
+++ b/documentdb-chart/crds/db.microsoft.com_documentdbs.yaml
@@ -87,6 +87,11 @@ spec:
                 required:
                 - serviceType
                 type: object
+              gatewayImage:
+                description: |-
+                  GatewayImage is the container image to use for the DocumentDB Gateway sidecar.
+                  If not specified, defaults to a version that matches the DocumentDB operator version.
+                type: string
               instancesPerNode:
                 description: InstancesPerNode is the number of DocumentDB instances
                   per node. Must be 1.

--- a/documentdb-chart/templates/02_documentdb_sidecar_injector.yaml
+++ b/documentdb-chart/templates/02_documentdb_sidecar_injector.yaml
@@ -7,7 +7,7 @@ metadata:
     cnpg.io/pluginServerSecret: sidecarinjector-server-tls
   labels:
     app: sidecar-injector
-    cnpg.io/pluginName: cnpg-i-sidecar-injector.cloudnative-pg.io
+    cnpg.io/pluginName: cnpg-i-sidecar-injector.documentdb.io
   name: sidecar-injector
   namespace: cnpg-system
 spec:

--- a/internal/cnpg/cnpg_cluster.go
+++ b/internal/cnpg/cnpg_cluster.go
@@ -18,6 +18,11 @@ func GetCnpgClusterSpec(req ctrl.Request, documentdb dbpreview.DocumentDB, docum
 	if sidecarPluginName == "" {
 		sidecarPluginName = util.DEFAULT_SIDECAR_INJECTOR_PLUGIN
 	}
+
+	// Get the gateway image for this DocumentDB instance
+	gatewayImage := util.GetGatewayImageForDocumentDB(&documentdb)
+	log.Info("Creating CNPG cluster with gateway image", "gatewayImage", gatewayImage, "documentdbName", documentdb.Name, "specGatewayImage", documentdb.Spec.GatewayImage)
+
 	return &cnpgv1.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      req.Name,
@@ -35,6 +40,9 @@ func GetCnpgClusterSpec(req ctrl.Request, documentdb dbpreview.DocumentDB, docum
 				Plugins: []cnpgv1.PluginConfiguration{
 					{
 						Name: sidecarPluginName,
+						Parameters: map[string]string{
+							"gatewayImage": gatewayImage,
+						},
 					},
 				},
 				PostgresUID: 105,

--- a/internal/utils/constants.go
+++ b/internal/utils/constants.go
@@ -13,6 +13,7 @@ const (
 	ENABLE_SCALING_CONTROLLER_ENV = "ENABLE_SCALING_CONTROLLER"
 
 	DEFAULT_DOCUMENTDB_IMAGE = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	DEFAULT_GATEWAY_IMAGE    = "ghcr.io/microsoft/documentdb/documentdb-local:16"
 
 	LABEL_APP                      = "app"
 	LABEL_REPLICA_TYPE             = "replica_type"
@@ -24,7 +25,7 @@ const (
 
 	DOCUMENTDB_SERVICE_PREFIX = "documentdb-service-"
 
-	DEFAULT_SIDECAR_INJECTOR_PLUGIN = "cnpg-i-sidecar-injector.cloudnative-pg.io"
+	DEFAULT_SIDECAR_INJECTOR_PLUGIN = "cnpg-i-sidecar-injector.documentdb.io"
 
 	CNPG_DEFAULT_STOP_DELAY = 30
 )

--- a/internal/utils/util.go
+++ b/internal/utils/util.go
@@ -261,3 +261,20 @@ func getDocumentDbUsername() string {
 	// For now, we return a default username.
 	return "default_user"
 }
+
+// GetGatewayImageForDocumentDB returns the gateway image for a DocumentDB instance.
+// If GatewayImage is specified in the spec, it uses that; otherwise it returns a default
+// based on the unified versioning strategy.
+func GetGatewayImageForDocumentDB(documentdb *dbpreview.DocumentDB) string {
+	if documentdb.Spec.GatewayImage != "" {
+		return documentdb.Spec.GatewayImage
+	}
+
+	// Use environment variable if set (for unified versioning)
+	if gatewayImage := os.Getenv("DOCUMENTDB_GATEWAY_IMAGE"); gatewayImage != "" {
+		return gatewayImage
+	}
+
+	// Fall back to default
+	return DEFAULT_GATEWAY_IMAGE
+}

--- a/plugins/sidecar-injector/internal/config/config.go
+++ b/plugins/sidecar-injector/internal/config/config.go
@@ -13,14 +13,16 @@ import (
 )
 
 const (
-	labelsParameter     = "labels"
-	annotationParameter = "annotations"
+	labelsParameter       = "labels"
+	annotationParameter   = "annotations"
+	gatewayImageParameter = "gatewayImage"
 )
 
 // Configuration represents the plugin configuration parameters
 type Configuration struct {
-	Labels      map[string]string
-	Annotations map[string]string
+	Labels       map[string]string
+	Annotations  map[string]string
+	GatewayImage string
 }
 
 // FromParameters builds a plugin configuration from the configuration parameters
@@ -49,9 +51,13 @@ func FromParameters(
 		}
 	}
 
+	// Parse gateway image parameter
+	gatewayImage := helper.Parameters[gatewayImageParameter]
+
 	configuration := &Configuration{
-		Labels:      labels,
-		Annotations: annotations,
+		Labels:       labels,
+		Annotations:  annotations,
+		GatewayImage: gatewayImage,
 	}
 
 	configuration.applyDefaults()
@@ -89,6 +95,10 @@ func (config *Configuration) applyDefaults() {
 			"plugin-metadata": "default",
 		}
 	}
+	// Set default gateway image if not specified
+	if config.GatewayImage == "" {
+		config.GatewayImage = "ghcr.io/microsoft/documentdb/documentdb-local:16"
+	}
 }
 
 // ToParameters serialize the configuration to a map of plugin parameters
@@ -104,6 +114,7 @@ func (config *Configuration) ToParameters() (map[string]string, error) {
 	}
 	result[labelsParameter] = string(serializedLabels)
 	result[annotationParameter] = string(serializedAnnotations)
+	result[gatewayImageParameter] = config.GatewayImage
 
 	return result, nil
 }

--- a/scripts/deployment-examples/single-node-documentdb.yaml
+++ b/scripts/deployment-examples/single-node-documentdb.yaml
@@ -13,7 +13,9 @@ spec:
   nodeCount: 1
   instancesPerNode: 1
   documentDBImage: ghcr.io/microsoft/documentdb/documentdb-local:16
+  gatewayImage: ghcr.io/microsoft/documentdb/documentdb-local:16
   resource:
     pvcSize: 10Gi
   exposeViaService:
     serviceType: LoadBalancer
+  sidecarInjectorPluginName: cnpg-i-sidecar-injector.documentdb.io


### PR DESCRIPTION
This PR exposes sidecar-injector configuration. We start with `gatewayImage`. Customer can pass it in the DocumentDB spac which is automatically passed to the CNPG sidecar injector as parameters.

## Test:
Tested by deploying to AKS cluster. 